### PR TITLE
Improve monitoring configuration clarity

### DIFF
--- a/blackbox.yml
+++ b/blackbox.yml
@@ -1,28 +1,31 @@
 modules:
+  # ICMP Ping Module - Basic network connectivity testing
   icmp:
     prober: icmp
     timeout: 5s
     icmp:
-      preferred_ip_protocol: "ip4"
-      source_ip_address: ""
-      payload_size: 56
-      dont_fragment: false
+      preferred_ip_protocol: "ip4"  # Use IPv4 for consistency
+      source_ip_address: ""         # Use default source IP
+      payload_size: 56              # Standard ICMP payload size
+      dont_fragment: false          # Allow packet fragmentation if needed
   
+  # HTTP 2xx Module - Standard HTTP service monitoring
   http_2xx:
     prober: http
     timeout: 5s
     http:
-      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
-      valid_status_codes: []  # Defaults to 2xx
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]  # Support both HTTP versions
+      valid_status_codes: []  # Defaults to 2xx status codes (200-299)
       method: GET
       headers:
         User-Agent: "Prometheus-Blackbox-Exporter/1.0"
       follow_redirects: true
-      fail_if_ssl: false
-      fail_if_not_ssl: false
+      fail_if_ssl: false      # Don't fail if SSL is present
+      fail_if_not_ssl: false  # Don't fail if SSL is not present
       tls_config:
-        insecure_skip_verify: false
+        insecure_skip_verify: false  # Verify SSL certificates
   
+  # HTTP POST Module - For API endpoints that require POST requests
   http_post_2xx:
     prober: http
     timeout: 5s
@@ -30,49 +33,54 @@ modules:
       method: POST
       headers:
         Content-Type: "application/json"
-      body: '{}'
+      body: '{}'  # Empty JSON body for health checks
   
+  # TCP Connect Module - Basic TCP port connectivity testing
   tcp_connect:
     prober: tcp
     timeout: 5s
   
+  # DNS Resolution Module - DNS server functionality testing
   dns:
     prober: dns
     timeout: 5s
     dns:
-      query_name: "google.com"
-      query_type: "A"
+      query_name: "google.com"  # Test DNS resolution with a reliable domain
+      query_type: "A"           # Query for A records (IPv4 addresses)
       valid_rcodes:
-      - NOERROR
+      - NOERROR                 # Accept successful DNS responses
   
+  # HTTP SSL Module - HTTPS service monitoring with SSL certificate validation
   http_ssl:
     prober: http
-    timeout: 10s
+    timeout: 10s  # Longer timeout for SSL handshake
     http:
       valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
-      valid_status_codes: []
+      valid_status_codes: []  # Defaults to 2xx status codes
       method: GET
       headers:
         User-Agent: "Prometheus-Blackbox-Exporter/1.0"
       follow_redirects: true
-      fail_if_ssl: false
-      fail_if_not_ssl: true
+      fail_if_ssl: false      # Don't fail if SSL is present
+      fail_if_not_ssl: true   # Fail if SSL is not present (require HTTPS)
       tls_config:
-        insecure_skip_verify: false
+        insecure_skip_verify: false  # Verify SSL certificates
   
+  # TCP SSH Module - SSH service detection and validation
   tcp_ssh:
     prober: tcp
     timeout: 5s
     tcp:
       preferred_ip_protocol: "ip4"
       query_response:
-        - expect: "^SSH-2.0-"
+        - expect: "^SSH-2.0-"  # Expect SSH version string in response
   
+  # TCP HTTP Module - Basic HTTP service detection via TCP
   tcp_http:
     prober: tcp
     timeout: 5s
     tcp:
       preferred_ip_protocol: "ip4"
       query_response:
-        - send: "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
-        - expect: "HTTP/1.1 200 OK"
+        - send: "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"  # Send HTTP request
+        - expect: "HTTP/1.1 200 OK"  # Expect successful HTTP response

--- a/prometheus-rules.yml
+++ b/prometheus-rules.yml
@@ -2,17 +2,17 @@ groups:
   - name: network_monitoring
     rules:
       # Ping/ICMP Alerts
-      - alert: HostDown
-        expr: probe_success{job="blackbox"} == 0
+      - alert: PingConnectivityDown
+        expr: probe_success{job="ping_connectivity_monitoring"} == 0
         for: 2m
         labels:
           severity: critical
         annotations:
-          summary: "Host {{ $labels.instance }} is down"
-          description: "Host {{ $labels.instance }} has been down for more than 2 minutes."
+          summary: "Ping connectivity to {{ $labels.instance }} is down"
+          description: "Cannot ping {{ $labels.instance }} for more than 2 minutes. This may indicate network connectivity issues."
       
       - alert: HighPingLatency
-        expr: probe_icmp_duration_seconds{job="blackbox"} > 0.1
+        expr: probe_icmp_duration_seconds{job="ping_connectivity_monitoring"} > 0.1
         for: 5m
         labels:
           severity: warning
@@ -21,7 +21,7 @@ groups:
           description: "Ping latency to {{ $labels.instance }} is {{ $value }}s (>100ms) for more than 5 minutes."
       
       - alert: PingPacketLoss
-        expr: avg_over_time(probe_success{job="blackbox"}[5m]) < 0.95
+        expr: avg_over_time(probe_success{job="ping_connectivity_monitoring"}[5m]) < 0.95
         for: 3m
         labels:
           severity: warning
@@ -29,18 +29,27 @@ groups:
           summary: "Packet loss detected to {{ $labels.instance }}"
           description: "Packet loss to {{ $labels.instance }} is above 5% over the last 5 minutes (success rate: {{ $value }})"
       
-      # HTTP Alerts
-      - alert: HTTPServiceDown
-        expr: probe_success{job="blackbox_http"} == 0
+      # HTTP Service Alerts
+      - alert: LocalHTTPServiceDown
+        expr: probe_success{job="http_service_monitoring"} == 0
         for: 1m
         labels:
           severity: critical
         annotations:
-          summary: "HTTP service {{ $labels.instance }} is down"
-          description: "HTTP service {{ $labels.instance }} has been down for more than 1 minute."
+          summary: "Local HTTP service {{ $labels.instance }} is down"
+          description: "Local HTTP service {{ $labels.instance }} has been down for more than 1 minute."
+      
+      - alert: ExternalHTTPConnectivityDown
+        expr: probe_success{job="external_http_connectivity"} == 0
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "External HTTP connectivity to {{ $labels.instance }} is down"
+          description: "Cannot reach external HTTP service {{ $labels.instance }} for more than 2 minutes."
       
       - alert: HTTPHighResponseTime
-        expr: probe_http_duration_seconds{job="blackbox_http"} > 5
+        expr: probe_http_duration_seconds{job=~"http_service_monitoring|external_http_connectivity"} > 5
         for: 3m
         labels:
           severity: warning
@@ -49,7 +58,7 @@ groups:
           description: "HTTP response time for {{ $labels.instance }} is {{ $value }}s (>5s) for more than 3 minutes."
       
       - alert: HTTPStatusCodeError
-        expr: probe_http_status_code{job="blackbox_http"} >= 400
+        expr: probe_http_status_code{job=~"http_service_monitoring|external_http_connectivity"} >= 400
         for: 1m
         labels:
           severity: warning
@@ -58,18 +67,27 @@ groups:
           description: "HTTP service {{ $labels.instance }} returned status code {{ $value }} for more than 1 minute."
       
       # DNS Alerts
-      - alert: DNSLookupSlow
-        expr: probe_dns_lookup_time_seconds > 1
+      - alert: DNSResolutionSlow
+        expr: probe_dns_lookup_time_seconds{job="dns_resolution_monitoring"} > 1
         for: 2m
         labels:
           severity: warning
         annotations:
-          summary: "Slow DNS lookup for {{ $labels.instance }}"
-          description: "DNS lookup for {{ $labels.instance }} is taking {{ $value }}s (>1s) for more than 2 minutes."
+          summary: "Slow DNS resolution for {{ $labels.instance }}"
+          description: "DNS resolution for {{ $labels.instance }} is taking {{ $value }}s (>1s) for more than 2 minutes."
       
-      # Certificate Expiry (if SSL monitoring is enabled)
+      - alert: DNSResolutionDown
+        expr: probe_success{job="dns_resolution_monitoring"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "DNS resolution service {{ $labels.instance }} is down"
+          description: "DNS resolution service {{ $labels.instance }} has been down for more than 2 minutes."
+      
+      # SSL Certificate Alerts
       - alert: SSLCertificateExpiringSoon
-        expr: probe_ssl_earliest_cert_expiry{job="blackbox_http"} - time() < 86400 * 30
+        expr: probe_ssl_earliest_cert_expiry{job="ssl_certificate_monitoring"} - time() < 86400 * 30
         for: 1h
         labels:
           severity: warning
@@ -78,19 +96,29 @@ groups:
           description: "SSL certificate for {{ $labels.instance }} expires within 30 days (expiry timestamp: {{ $value }})"
       
       - alert: SSLCertificateExpired
-        expr: probe_ssl_earliest_cert_expiry{job="blackbox_http"} - time() <= 0
+        expr: probe_ssl_earliest_cert_expiry{job="ssl_certificate_monitoring"} - time() <= 0
         for: 1m
         labels:
           severity: critical
         annotations:
           summary: "SSL certificate for {{ $labels.instance }} has expired"
           description: "SSL certificate for {{ $labels.instance }} has expired."
+      
+      # TCP Port Connectivity Alerts
+      - alert: TCPPortUnreachable
+        expr: probe_success{job="tcp_port_connectivity"} == 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "TCP port {{ $labels.instance }} is unreachable"
+          description: "Cannot connect to TCP port {{ $labels.instance }} for more than 1 minute."
 
   - name: infrastructure_monitoring
     rules:
       # Local Network Infrastructure
       - alert: LocalGatewayDown
-        expr: probe_success{instance="192.168.254.254"} == 0
+        expr: probe_success{job="ping_connectivity_monitoring", instance="192.168.254.254"} == 0
         for: 1m
         labels:
           severity: critical
@@ -99,7 +127,7 @@ groups:
           description: "Cannot reach local network gateway (192.168.254.254). This may indicate a network infrastructure issue."
       
       - alert: NASUnreachable
-        expr: probe_success{instance="nas.lan"} == 0
+        expr: probe_success{job="ping_connectivity_monitoring", instance="nas.lan"} == 0
         for: 2m
         labels:
           severity: warning
@@ -108,10 +136,19 @@ groups:
           description: "Network Attached Storage (nas.lan) has been unreachable for more than 2 minutes."
       
       - alert: ServerUnreachable
-        expr: probe_success{instance="r630.lan"} == 0
+        expr: probe_success{job="ping_connectivity_monitoring", instance="r630.lan"} == 0
         for: 2m
         labels:
           severity: warning
         annotations:
           summary: "R630 server is unreachable"
           description: "Dell R630 server (r630.lan) has been unreachable for more than 2 minutes."
+      
+      - alert: LocalNetworkDeviceDown
+        expr: probe_success{job="ping_connectivity_monitoring", instance="192.168.254.9"} == 0
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Local network device is unreachable"
+          description: "Local network device (192.168.254.9) has been unreachable for more than 3 minutes."

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -6,7 +6,7 @@ rule_files:
   - "prometheus-recording-rules.yml"
 
 scrape_configs:
-  - job_name: 'blackbox'
+  - job_name: 'ping_connectivity_monitoring'
     metrics_path: /probe
     params:
       module: [icmp]
@@ -21,12 +21,39 @@ scrape_configs:
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target
-      - target_label: instance
-        replacement: blackbox
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: service_type
+        replacement: ping
       - target_label: __address__
         replacement: blackbox_exporter:9115
+      # Add descriptive labels based on target
+      - source_labels: [__param_target]
+        regex: '8\.8\.8\.8'
+        target_label: target_type
+        replacement: 'external_dns'
+      - source_labels: [__param_target]
+        regex: '1\.1\.1\.1'
+        target_label: target_type
+        replacement: 'external_dns'
+      - source_labels: [__param_target]
+        regex: '192\.168\.254\.254'
+        target_label: target_type
+        replacement: 'local_gateway'
+      - source_labels: [__param_target]
+        regex: '192\.168\.254\.9'
+        target_label: target_type
+        replacement: 'local_device'
+      - source_labels: [__param_target]
+        regex: 'nas\.lan'
+        target_label: target_type
+        replacement: 'nas_storage'
+      - source_labels: [__param_target]
+        regex: 'r630\.lan'
+        target_label: target_type
+        replacement: 'dell_server'
 
-  - job_name: 'blackbox_http'
+  - job_name: 'http_service_monitoring'
     metrics_path: /probe
     params:
       module: [http_2xx]
@@ -40,10 +67,25 @@ scrape_configs:
         target_label: __param_target
       - source_labels: [__param_target]
         target_label: instance
+      - target_label: service_type
+        replacement: http
       - target_label: __address__
         replacement: blackbox_exporter:9115
+      # Add descriptive labels for HTTP services
+      - source_labels: [__param_target]
+        regex: 'https://home\.jomby\.xyz'
+        target_label: target_type
+        replacement: 'personal_website'
+      - source_labels: [__param_target]
+        regex: 'http://nas\.lan:9090'
+        target_label: target_type
+        replacement: 'nas_cockpit'
+      - source_labels: [__param_target]
+        regex: 'http://r630\.lan:9090'
+        target_label: target_type
+        replacement: 'server_cockpit'
 
-  - job_name: 'blackbox_http_redirects'
+  - job_name: 'external_http_connectivity'
     metrics_path: /probe
     params:
       module: [http_2xx]
@@ -56,25 +98,43 @@ scrape_configs:
         target_label: __param_target
       - source_labels: [__param_target]
         target_label: instance
+      - target_label: service_type
+        replacement: external_http
       - target_label: __address__
         replacement: blackbox_exporter:9115
+      # Add descriptive labels for external services
+      - source_labels: [__param_target]
+        regex: 'https://httpbin\.org/status/200'
+        target_label: target_type
+        replacement: 'test_service'
+      - source_labels: [__param_target]
+        regex: 'https://github\.com'
+        target_label: target_type
+        replacement: 'development_platform'
 
-  - job_name: 'blackbox_dns'
+  - job_name: 'dns_resolution_monitoring'
     metrics_path: /probe
     params:
       module: [dns]
     static_configs:
       - targets:
-        - 192.168.254.11
+        - 192.168.254.11  # Pi-hole DNS server
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target
       - source_labels: [__param_target]
         target_label: instance
+      - target_label: service_type
+        replacement: dns
       - target_label: __address__
         replacement: blackbox_exporter:9115
+      # Add descriptive labels for DNS services
+      - source_labels: [__param_target]
+        regex: '192\.168\.254\.11'
+        target_label: target_type
+        replacement: 'pihole_dns'
 
-  - job_name: 'blackbox_ssl'
+  - job_name: 'ssl_certificate_monitoring'
     metrics_path: /probe
     params:
       module: [http_ssl]
@@ -88,10 +148,25 @@ scrape_configs:
         target_label: __param_target
       - source_labels: [__param_target]
         target_label: instance
+      - target_label: service_type
+        replacement: ssl
       - target_label: __address__
         replacement: blackbox_exporter:9115
+      # Add descriptive labels for SSL services
+      - source_labels: [__param_target]
+        regex: 'https://home\.jomby\.xyz'
+        target_label: target_type
+        replacement: 'personal_website_ssl'
+      - source_labels: [__param_target]
+        regex: 'https://github\.com'
+        target_label: target_type
+        replacement: 'development_platform_ssl'
+      - source_labels: [__param_target]
+        regex: 'https://httpbin\.org/status/200'
+        target_label: target_type
+        replacement: 'test_service_ssl'
 
-  - job_name: 'blackbox_tcp'
+  - job_name: 'tcp_port_connectivity'
     metrics_path: /probe
     params:
       module: [tcp_connect]
@@ -107,6 +182,29 @@ scrape_configs:
         target_label: __param_target
       - source_labels: [__param_target]
         target_label: instance
+      - target_label: service_type
+        replacement: tcp
       - target_label: __address__
         replacement: blackbox_exporter:9115
+      # Add descriptive labels for TCP services
+      - source_labels: [__param_target]
+        regex: 'r630\.lan:22'
+        target_label: target_type
+        replacement: 'server_ssh'
+      - source_labels: [__param_target]
+        regex: 'r630\.lan:9090'
+        target_label: target_type
+        replacement: 'server_cockpit_tcp'
+      - source_labels: [__param_target]
+        regex: 'nas\.lan:9090'
+        target_label: target_type
+        replacement: 'nas_cockpit_tcp'
+      - source_labels: [__param_target]
+        regex: 'nas\.lan:443'
+        target_label: target_type
+        replacement: 'nas_https'
+      - source_labels: [__param_target]
+        regex: 'nas\.lan:22'
+        target_label: target_type
+        replacement: 'nas_ssh'
 


### PR DESCRIPTION
- Rename all job names to be descriptive and clear:
  * blackbox_need_more_name → ping_connectivity_monitoring
  * blackbox_http → http_service_monitoring
  * blackbox_http_redirects → external_http_connectivity
  * blackbox_dns_pihole → dns_resolution_monitoring
  * blackbox_ssl → ssl_certificate_monitoring
  * blackbox_tcp_ssh_9090 → tcp_port_connectivity

- Update alert rules to reference correct job names
- Add comprehensive target_type labels for better identification
- Improve blackbox module documentation with detailed comments
- Add service_type labels to all monitoring jobs
- Update alert descriptions for better clarity